### PR TITLE
Add security context field

### DIFF
--- a/artifacts/examples/crd-minecraftserver.yaml
+++ b/artifacts/examples/crd-minecraftserver.yaml
@@ -28,6 +28,30 @@ spec:
                   type: string
                 replicas:
                   type: integer
+                securityContext:
+                  type: object
+                  properties:
+                    runAsUser:
+                      type: integer
+                    runAsGroup:
+                      type: integer
+                    fsGroup:
+                      type: integer
+                    seLinuxOptions:
+                      type: object
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                    supplementalGroups:
+                      type: array
+                      items:
+                        type: integer
                 dataVolume:
                   type: object
                   properties:

--- a/pkg/apis/minecraftserver/v1alpha1/types.go
+++ b/pkg/apis/minecraftserver/v1alpha1/types.go
@@ -52,6 +52,8 @@ type MinecraftServerSpec struct {
 	DataVolume *MinecraftPersistentVolume `json:"dataVolume,omitempty"`
 	// Replicas sets the number of replicas to run for the Minecraft server.
 	Replicas int32 `json:"replicas,omitempty"`
+	// SecurityContext is the security context to apply to the Minecraft server pod.
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	// ServerSettings is a set of settings to apply to the Minecraft server.
 	ServerSettings MinecraftServerSettings `json:"serverSettings"`
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This change adds support for setting SecurityContext properties for the Minecraft server pods.


* **What is the current behavior?** (You can also link to an open issue here)

SecurityContext cannot be set using a MinecraftServer API object. 

* **What is the new behavior (if this is a feature change)?**

SecurityContext can be set using a MinecraftServer API object

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

